### PR TITLE
feat: Bring action descriptions up-to-date

### DIFF
--- a/test-interface.jsonld
+++ b/test-interface.jsonld
@@ -249,7 +249,7 @@
       "@id": "test:SellerRequestedCancellationSimulateAction",
       "@type": "Class",
       "label": "SellerRequestedCancellationSimulationAction",
-      "comment": "Simulate a [Seller requested cancellation](https://www.openactive.io/open-booking-api/EditorsDraft/#seller-requested-cancellation) for at least one `OrderItem`.",
+      "comment": "Simulate the seller cancelling an activity that a customer has booked ([spec](https://www.openactive.io/open-booking-api/EditorsDraft/#seller-requested-cancellation)). Expectations: An OrderItem's `orderItemStatus` changes to `https://openactive.io/SellerCancelled`; and the Order is updated in the booking system's [Orders RPDE feed](https://openactive.io/open-booking-api/EditorsDraft/#orders-feed-notifications-updates-and-refunds).",
       "subClassOf": [
         "test:OpenBookingSimulateAction"
       ]
@@ -258,7 +258,7 @@
       "@id": "test:SellerRequestedCancellationWithMessageSimulateAction",
       "@type": "Class",
       "label": "SellerRequestedCancellationWithMessageSimulateAction",
-      "comment": "Simulate a [Seller requested cancellation](https://www.openactive.io/open-booking-api/EditorsDraft/#seller-requested-cancellation) for at least one `OrderItem`, with a `cancellationMessage` provided.",
+      "comment": "Simulate the seller cancelling an activity that a customer has booked, and providing a message to the customer ([spec](https://www.openactive.io/open-booking-api/EditorsDraft/#seller-requested-cancellation)). Expectations: An OrderItem's `orderItemStatus` changes to `https://openactive.io/SellerCancelled`, and the same OrderItem has a `cancellationMessage` set; and the Order is updated in the booking system's [Orders RPDE feed](https://openactive.io/open-booking-api/EditorsDraft/#orders-feed-notifications-updates-and-refunds).",
       "subClassOf": [
         "test:OpenBookingSimulateAction"
       ]
@@ -267,7 +267,7 @@
       "@id": "test:ReplacementSimulateAction",
       "@type": "Class",
       "label": "ReplacementSimulateAction",
-      "comment": "Simulate a [Replacement](https://www.openactive.io/open-booking-api/EditorsDraft/#cancellation-replacement-refund-calculation-and-notification).",
+      "comment": "Simulate replacing a customer's booked Opportunity with another equivalent one ([spec](https://www.openactive.io/open-booking-api/EditorsDraft/#cancellation-replacement-refund-calculation-and-notification)). Expectations: An OrderItem should have its booked Opportunity (via `.orderedItem`) changed to a different Opportunity with, among other things, a different ID; and the Order is updated in the booking system's [Orders RPDE feed](https://openactive.io/open-booking-api/EditorsDraft/#orders-feed-notifications-updates-and-refunds), with the replaced opportunity included.",
       "subClassOf": [
         "test:OpenBookingSimulateAction"
       ]
@@ -276,7 +276,7 @@
       "@id": "test:CustomerNoticeSimulateAction",
       "@type": "Class",
       "label": "CustomerNoticeSimulateAction",
-      "comment": "Simulate a [Customer Notice](https://www.openactive.io/open-booking-api/EditorsDraft/#customer-notice-notifications).",
+      "comment": "Simulate providing a notice to a customer about a booking that they have made ([spec](https://openactive.io/open-booking-api/EditorsDraft/#customer-notice-notifications)). Expectations: An OrderItem should have `customerNotice` set to some text; and the Order is updated in the booking system's [Orders RPDE feed](https://openactive.io/open-booking-api/EditorsDraft/#orders-feed-notifications-updates-and-refunds).",
       "subClassOf": [
         "test:OpenBookingSimulateAction"
       ]
@@ -285,7 +285,7 @@
       "@id": "test:ChangeOfLogisticsTimeSimulateAction",
       "@type": "Class",
       "label": "ChangeOfLogisticsTimeSimulateAction",
-      "comment": "Simulate a time related [Change of Logistics](https://www.openactive.io/open-booking-api/EditorsDraft/#change-of-logistics-notifications).",
+      "comment": "Simulate changing the time of an Opportunity after a customer has already booked it ([spec](https://openactive.io/open-booking-api/EditorsDraft/#change-of-logistics-notifications), with the opportunity data in the Orders as defined in [issue #198](https://github.com/openactive/open-booking-api/issues/198)). Expectations: A booked Opportunity's `startDate`, `endDate`, or `duration` changes to a new value; and the Order is updated in the booking system's [Orders RPDE feed](https://openactive.io/open-booking-api/EditorsDraft/#orders-feed-notifications-updates-and-refunds), with the modified opportunity data included.",
       "subClassOf": [
         "test:OpenBookingSimulateAction"
       ]
@@ -294,7 +294,7 @@
       "@id": "test:ChangeOfLogisticsNameSimulateAction",
       "@type": "Class",
       "label": "ChangeOfLogisticsNameSimulateAction",
-      "comment": "Simulate a name related [Change of Logistics](https://www.openactive.io/open-booking-api/EditorsDraft/#change-of-logistics-notifications).",
+      "comment": "Simulate changing the name of an Opportunity after a customer has already booked it ([spec](https://openactive.io/open-booking-api/EditorsDraft/#change-of-logistics-notifications), with the opportunity data in the Orders as defined in [issue #198](https://github.com/openactive/open-booking-api/issues/198)). Expectations: A booked Opportunity's `name` changes to a new value; and the Order is updated in the booking system's [Orders RPDE feed](https://openactive.io/open-booking-api/EditorsDraft/#orders-feed-notifications-updates-and-refunds), with the modified opportunity data included.",
       "subClassOf": [
         "test:OpenBookingSimulateAction"
       ]
@@ -303,7 +303,7 @@
       "@id": "test:ChangeOfLogisticsLocationSimulateAction",
       "@type": "Class",
       "label": "ChangeOfLogisticsLocationSimulateAction",
-      "comment": "Simulate a location related [Change of Logistics](https://www.openactive.io/open-booking-api/EditorsDraft/#change-of-logistics-notifications).",
+      "comment": "Simulate changing the location of an Opportunity after a customer has already booked it ([spec](https://openactive.io/open-booking-api/EditorsDraft/#change-of-logistics-notifications), with the opportunity data in the Orders as defined in [issue #198](https://github.com/openactive/open-booking-api/issues/198)). Expectations: A booked Opportunity's `location` changes to a new value; and the Order is updated in the booking system's [Orders RPDE feed](https://openactive.io/open-booking-api/EditorsDraft/#orders-feed-notifications-updates-and-refunds), with the modified opportunity data included.",
       "subClassOf": [
         "test:OpenBookingSimulateAction"
       ]
@@ -312,7 +312,7 @@
       "@id": "test:AttendeeAttendedSimulateAction",
       "@type": "Class",
       "label": "AttendeeAttendedSimulateAction",
-      "comment": "Simulate an [Opportunity Attendance Update](https://www.openactive.io/open-booking-api/EditorsDraft/#opportunity-attendance-updates) of `https://openactive.io/AttendeeAttended`.",
+      "comment": "Simulate confirming a customer as not having attended the activity that they booked ([spec](https://openactive.io/open-booking-api/EditorsDraft/#opportunity-attendance-updates), with updated status values as defined in [issue #199](https://github.com/openactive/open-booking-api/issues/199)). Expectations: An OrderItem's `orderItemStatus` changes to `https://openactive.io/AttendeeAttended`; and the Order is updated in the booking system's [Orders RPDE feed](https://openactive.io/open-booking-api/EditorsDraft/#orders-feed-notifications-updates-and-refunds).",
       "subClassOf": [
         "test:OpenBookingSimulateAction"
       ]
@@ -321,7 +321,7 @@
       "@id": "test:AttendeeAbsentSimulateAction",
       "@type": "Class",
       "label": "AttendeeAbsentSimulateAction",
-      "comment": "Simulate an [Opportunity Attendance Update](https://www.openactive.io/open-booking-api/EditorsDraft/#opportunity-attendance-updates) of `https://openactive.io/AttendeeAbsent`.",
+      "comment": "Simulate confirming a customer as not having attended the activity that they booked ([spec](https://openactive.io/open-booking-api/EditorsDraft/#opportunity-attendance-updates), with updated status values as defined in [issue #199](https://github.com/openactive/open-booking-api/issues/199)). Expectations: An OrderItem's `orderItemStatus` changes to `https://openactive.io/AttendeeAbsent`; and the Order is updated in the booking system's [Orders RPDE feed](https://openactive.io/open-booking-api/EditorsDraft/#orders-feed-notifications-updates-and-refunds).",
       "subClassOf": [
         "test:OpenBookingSimulateAction"
       ]
@@ -330,7 +330,7 @@
       "@id": "test:AccessPassUpdateSimulateAction",
       "@type": "Class",
       "label": "AccessPassUpdateSimulateAction",
-      "comment": "Simulate an [`accessPass` Update](https://www.openactive.io/open-booking-api/EditorsDraft/#other-notifications).",
+      "comment": "Simulate an update to a booking's `accessPass` ([spec](https://www.openactive.io/open-booking-api/EditorsDraft/#other-notifications)). Expectations: An OrderItem's `accessPass` changes to a new value; and the Order is updated in the booking system's [Orders RPDE feed](https://openactive.io/open-booking-api/EditorsDraft/#orders-feed-notifications-updates-and-refunds).",
       "subClassOf": [
         "test:OpenBookingSimulateAction"
       ]
@@ -339,7 +339,7 @@
       "@id": "test:AccessCodeUpdateSimulateAction",
       "@type": "Class",
       "label": "AccessCodeUpdateSimulateAction",
-      "comment": "Simulate an [`accessCode` Update](https://www.openactive.io/open-booking-api/EditorsDraft/#other-notifications).",
+      "comment": "Simulate an update to a booking's `accessCode` ([spec](https://www.openactive.io/open-booking-api/EditorsDraft/#other-notifications)). Expectations: An OrderItem's `accessCode` changes to a new value; and the Order is updated in the booking system's [Orders RPDE feed](https://openactive.io/open-booking-api/EditorsDraft/#orders-feed-notifications-updates-and-refunds).",
       "subClassOf": [
         "test:OpenBookingSimulateAction"
       ]
@@ -348,7 +348,7 @@
       "@id": "test:SellerAcceptOrderProposalSimulateAction",
       "@type": "Class",
       "label": "SellerAcceptOrderProposalSimulateAction",
-      "comment": "Simulate [Proposal Approval of an `OrderProposal`](https://openactive.io/open-booking-api/EditorsDraft/#proposal-approval).",
+      "comment": "Simulate the seller approving a customer's [OrderProposal](https://openactive.io/open-booking-api/EditorsDraft/#minimal-proposal-implementation) ([spec](https://openactive.io/open-booking-api/EditorsDraft/#proposal-amendment), with the Order Proposals RPDE feed as defined in [issue #197](https://github.com/openactive/open-booking-api/issues/197)). Expectations: It should now be possible to complete the booking with **[B](https://openactive.io/open-booking-api/EditorsDraft/#dfn-b)**; the OrderProposal's `orderProposalStatus` is set to `https://openactive.io/SellerAccepted`; and the OrderProposal is updated in the booking system's [Order Proposals RPDE feed](https://github.com/openactive/open-booking-api/issues/197).",
       "subClassOf": [
         "test:OpenBookingSimulateAction"
       ]
@@ -357,7 +357,7 @@
       "@id": "test:SellerAmendOrderProposalSimulateAction",
       "@type": "Class",
       "label": "SellerAmendOrderProposalSimulateAction",
-      "comment": "Simulate [Proposal Amendment of an `OrderProposal`](https://openactive.io/open-booking-api/EditorsDraft/1.0CR3/#proposal-amendment).",
+      "comment": "Simulate the seller amending a customer's [OrderProposal](https://openactive.io/open-booking-api/EditorsDraft/#minimal-proposal-implementation) ([spec](https://openactive.io/open-booking-api/EditorsDraft/#proposal-approval), with the Order Proposals RPDE feed as defined in [issue #197](https://github.com/openactive/open-booking-api/issues/197)). Expectations: The OrderProposal's `orderProposalVersion` is changed and later attempts to complete the booking with **[B](https://openactive.io/open-booking-api/EditorsDraft/#dfn-b)** will only succeed with this new `orderProposalVersion`; and the OrderProposal is updated in the booking system's [Order Proposals RPDE feed](https://github.com/openactive/open-booking-api/issues/197).",
       "subClassOf": [
         "test:OpenBookingSimulateAction"
       ]
@@ -366,7 +366,7 @@
       "@id": "test:SellerRejectOrderProposalSimulateAction",
       "@type": "Class",
       "label": "SellerRejectOrderProposalSimulateAction",
-      "comment": "Simulate [Proposal Rejection of an `OrderProposal`](https://openactive.io/open-booking-api/EditorsDraft/#proposal-rejection).",
+      "comment": "Simulate the seller rejecting a customer's [OrderProposal](https://openactive.io/open-booking-api/EditorsDraft/#proposal-rejection) ([spec](https://openactive.io/open-booking-api/EditorsDraft/#proposal-approval), with the Order Proposals RPDE feed as defined in [issue #197](https://github.com/openactive/open-booking-api/issues/197)). Expectations: It should not be possible to complete the booking with **[B](https://openactive.io/open-booking-api/EditorsDraft/#dfn-b)**; the OrderProposal's `orderProposalStatus` is set to `https://openactive.io/SellerRejected`; and the OrderProposal is updated in the booking system's [Order Proposals RPDE feed](https://github.com/openactive/open-booking-api/issues/197).",
       "subClassOf": [
         "test:OpenBookingSimulateAction"
       ]
@@ -375,7 +375,7 @@
       "@id": "test:AccessChannelUpdateSimulateAction",
       "@type": "Class",
       "label": "AccessChannelUpdateSimulateAction",
-      "comment": "Simulate an [`accessChannel` Update](https://www.openactive.io/open-booking-api/EditorsDraft/#other-notifications).",
+      "comment": "Simulate an update to a booking's `accessChannel` ([spec](https://www.openactive.io/open-booking-api/EditorsDraft/#other-notifications)). Expectations: An OrderItem's `accessChannel` changes to a new value; and the Order is updated in the booking system's [Orders RPDE feed](https://openactive.io/open-booking-api/EditorsDraft/#orders-feed-notifications-updates-and-refunds).",
       "subClassOf": [
         "test:OpenBookingSimulateAction"
       ]


### PR DESCRIPTION
Part of https://github.com/openactive/developer-documentation/issues/71

(e.g. where tooling has outpaced the spec)

And, elaborate on action descriptions to make it easier for implementers to know what they need to do in order to pass Test Suite